### PR TITLE
Verify input is less or equal to Number.MAX_SAFE_INTEGER

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: node_js
 node_js:
   - iojs
-  - '0.10'
   - '0.12'
   - 'stable'
 before_script:

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ $ npm install sffc-encoder
 
 ### Encode
 Params:
-- number - takes any integer between 0 to 9007199254740992
+- number - takes any integer between 0 to 9007199254740991 (`Number.MAX_SAFE_INTEGER`)
 
 Returns a new Buffer holding the encoded Integer
 

--- a/sffcEncoder.js
+++ b/sffcEncoder.js
@@ -71,6 +71,7 @@ module.exports = {
   encode: function (number) {
     var buf
     if (number < 0) throw new Error('Number is out of bounds')
+    if (number > Number.MAX_SAFE_INTEGER) throw new Error('Number is out of bounds')
     if (number < 32) {
       buf = new Buffer([number])
       return buf

--- a/test/test.js
+++ b/test/test.js
@@ -1,7 +1,7 @@
 var balz = require(__dirname + '/../sffcEncoder')
 var assert = require('assert')
 var fullRunLength = 1000000
-var maxNumber = 9007199254740992
+var maxNumber = 9007199254740991
 var samples = [
   1,
   1200032,
@@ -23,8 +23,7 @@ var samples = [
   3333333333232323,
   2343241324231432,
   9007199254740991,
-  4823750656226800,
-  9007199254740992
+  4823750656226800
 ]
 
 var consumer = function (buff) {
@@ -79,7 +78,7 @@ describe('Encode/Decode', function (done) {
 describe('Should return errors', function (done) {
   it('Should throw errors', function (done) {
     this.timeout(0)
-    samples = [90071992547412996, -132, -1231]
+    samples = [9007199254740992, 10000000000000000000, -132, -1231]
     for (var i = 0; i < samples.length; i++) {
       assert.throws(function () {
         balz.encode(samples[i])


### PR DESCRIPTION
Candidate for incrementing minor.
We want to verify input is less than or equal to Number.MAX_SAFE_INTEGER (largest integer such that all smaller integers can safely represented).
